### PR TITLE
Enable high_voltage config through an initializer, and provide a handful of settings

### DIFF
--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,27 +1,29 @@
 class HighVoltage::PagesController < ApplicationController
-
+  caches_page *HighVoltage::caches_page
   unloadable
 
   rescue_from ActionView::MissingTemplate do |exception|
     if exception.message =~ %r{Missing template pages/}
-      raise ActionController::RoutingError, "No such page: #{params[:id]}"
+      raise ActionController::RoutingError, "No such page: #{params[:action]}"
     else
       raise exception
     end
   end
 
-  def show
+  def method_missing(name, *args, &block)
+    puts "Fuuuuu! #{name}"
     render :template => current_page
   end
 
   protected
 
     def current_page
-      "pages/#{clean_path}"
+      "#{HighVoltage::content_path}#{clean_path}"
     end
 
     def clean_path
-      path = Pathname.new "/#{params[:id]}"
+      puts "Params: #{params.inspect} - Action: #{params[:action]}"
+      path = Pathname.new "/#{params[:action]}"
       path.cleanpath.to_s[1..-1]
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  match '/pages/*id' => 'high_voltage/pages#show', :as => :page, :format => false
+  match '/pages/:action', :controller => 'high_voltage/pages', :as => :page, :format => false
 end

--- a/lib/high_voltage.rb
+++ b/lib/high_voltage.rb
@@ -1,3 +1,16 @@
 module HighVoltage
+  mattr_accessor :caches_page
+  @@caches_page = nil
+
+  mattr_accessor :layout
+  @@layout = "application"
+
+  mattr_accessor :content_path
+  @@content_path = "pages/"
+
+  def self.setup
+    yield self
+  end
+
   require 'high_voltage/engine' if defined?(Rails)
 end


### PR DESCRIPTION
This commit introduces a couple of changes:
- Changes the behaviour of HighVoltage::PagesController to use method_missing() instead of show(), and changes the route to use the second URL parameter as the :action parameter. This allows for the introduction of the :caches_page parameter in the controller, which allows us to cache views created by high_voltage.
- Introduces module accessors and a setup method to the high_voltage module and using them in the PagesController. This allows us to change the content path to use (pages/ by default), the layout directive to use ("application" by default), and the caches_page arguments (empty list by default).
