### PR TITLE
Add an example of the new content_path to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Customize
 
 High Voltage uses a default path and folder of 'pages', i.e. 'url.com/pages/contact' , 'app/views/pages'
 
-You can change this in an initializer. 
+You can change this in an initializer: 
 
     HighVoltage.content_path = "site/"
 


### PR DESCRIPTION
I had to look into the code to sort it out for myself, so I just stuck a little something into the readme. 
