### PR TITLE
Removed name spacing

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
-class HighVoltage::PagesController < ApplicationController
+class PagesController < ApplicationController
 
   unloadable
   layout HighVoltage::layout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  match "/#{HighVoltage::content_path}*id" => 'high_voltage/pages#show', :as => :page, :format => false
+  match "/#{HighVoltage::content_path}*id" => 'pages#show', :as => :page, :format => false
 
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe HighVoltage::PagesController do
+describe PagesController do
 
   render_views
 

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -15,15 +15,15 @@ describe 'routes' do
     end
 
     it "should recognize nested route" do
-      assert_recognizes({ :controller => "high_voltage/pages", :action => "show", :id => "one/two" }, "/pages/one/two")
+      assert_recognizes({ :controller => "pages", :action => "show", :id => "one/two" }, "/pages/one/two")
     end
 
     it "should recognize normal route" do
-      assert_recognizes({ :controller => "high_voltage/pages", :action => "show", :id => "one" }, "/pages/one")
+      assert_recognizes({ :controller => "pages", :action => "show", :id => "one" }, "/pages/one")
     end
 
     it "should recognize normal route with dots" do
-      assert_recognizes({ :controller => "high_voltage/pages", :action => "show", :id => "one.two.three" }, "/pages/one.two.three")
+      assert_recognizes({ :controller => "pages", :action => "show", :id => "one.two.three" }, "/pages/one.two.three")
     end
   end
 
@@ -47,15 +47,15 @@ describe 'routes' do
     end
 
     it "should recognize nested route" do
-      assert_recognizes({:controller => "high_voltage/pages", :action => "show", :id => "one/two"}, "/other_pages/one/two")
+      assert_recognizes({:controller => "pages", :action => "show", :id => "one/two"}, "/other_pages/one/two")
     end
 
     it "should recognize normal route" do
-      assert_recognizes({:controller => "high_voltage/pages", :action => "show", :id => "one"}, "/other_pages/one")
+      assert_recognizes({:controller => "pages", :action => "show", :id => "one"}, "/other_pages/one")
     end
 
     it "should recognize normal route with dots" do
-      assert_recognizes({:controller => "high_voltage/pages", :action => "show", :id => "one.two.three"}, "/other_pages/one.two.three")
+      assert_recognizes({:controller => "pages", :action => "show", :id => "one.two.three"}, "/other_pages/one.two.three")
     end
   end
 


### PR DESCRIPTION
It creates more trouble than it solves
Can not properly lookup the partials with namespacing

when we are using only a single conttroller, pages is as good as high_voltage.
