### PR TITLE
Fix for layout proc arity and Ruby 1.9

### DIFF
--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,7 +1,7 @@
 class HighVoltage::PagesController < ApplicationController
 
   unloadable
-  layout Proc.new { HighVoltage::layout }
+  layout Proc.new { |_| HighVoltage::layout }
 
   rescue_from ActionView::MissingTemplate do |exception|
     if exception.message =~ %r{Missing template #{content_path}}


### PR DESCRIPTION
Whoops, I didn't test against Ruby 1.9 and I see travis is failing.  This will fix the build for 1.9.
