### PR TITLE
PagesController should inherit from ActionController::Base instead of ApplicationController.

### DIFF
--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,4 +1,4 @@
-class HighVoltage::PagesController < ApplicationController
+class HighVoltage::PagesController < ActionController::Base
 
   unloadable
   layout Proc.new { |_| HighVoltage::layout }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -14,7 +14,7 @@ describe HighVoltage::PagesController do
         response.should render_template('exists')
       end
 
-      it "should use the default layout used by ApplicationController" do
+      it "should use the default layout used by ActionController::Base" do
         response.should render_template("layouts/application")
       end
     end


### PR DESCRIPTION
As the title says, `PagesController` should inherit from `ActionController::Base` instead of `ApplicationController`. The reason is that `ApplicationController` may not inherit from `ActionController::Base`, in which case `high_voltage` fails to work properly.
