### PR TITLE
Add a config option to disable default routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  match "/#{HighVoltage.content_path}*id" => 'high_voltage/pages#show', :as => :page, :format => false
-
+  unless HighVoltage.no_routes
+    match "/#{HighVoltage.content_path}*id" => 'high_voltage/pages#show', :as => :page, :format => false
+  end
 end

--- a/lib/high_voltage.rb
+++ b/lib/high_voltage.rb
@@ -7,6 +7,9 @@ module HighVoltage
   mattr_accessor :content_path
   @@content_path = "pages/"
 
+  mattr_accessor :no_routes
+  @@no_routes = false
+
   def self.setup
     yield self
   end

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -65,4 +65,14 @@ describe 'routes' do
     end
   end
 
+  context "with default configuration disabled" do
+    before do
+      HighVoltage.no_routes = true
+      Rails.application.reload_routes!
+    end
+
+    it "should not recognize routes" do
+      { :get => "/pages/one/two" }.should_not be_routable
+    end
+  end
 end


### PR DESCRIPTION
If you want more control over your routing you can disable the default routes in an initializer:

``` ruby
HighVoltage.no_routes = true
```

This is so you can fully customise the routes if you need too.
