### PR TITLE
Remove the ActionMailer usage

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 require "active_model/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
-require "action_mailer/railtie"
 
 Bundler.require
 require "high_voltage"

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -20,11 +20,6 @@ Dummy::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,6 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
 require "rspec/rails"
 
-ActionMailer::Base.delivery_method = :test
-ActionMailer::Base.perform_deliveries = true
-ActionMailer::Base.default_url_options[:host] = "test.com"
-
 Rails.backtrace_cleaner.remove_silencers!
 
 # Configure capybara for integration testing


### PR DESCRIPTION
We don't actually use `ActionMailer` in the test suite, but I ran into issues:

```
~/thoughtbot/high_voltage% bundle exec rspec spec/controllers/pages_controller_spec.rb
/home/mike/thoughtbot/high_voltage/spec/dummy/config/application.rb:6:in `require': no such file to load -- action_mailer/railtie (LoadError)
    from /home/mike/thoughtbot/high_voltage/spec/dummy/config/application.rb:6:in `<top (required)>'
    from /home/mike/thoughtbot/high_voltage/spec/dummy/config/environment.rb:2:in `require'
    from /home/mike/thoughtbot/high_voltage/spec/dummy/config/environment.rb:2:in `<top (required)>'
    from /home/mike/thoughtbot/high_voltage/spec/spec_helper.rb:4:in `require'
    from /home/mike/thoughtbot/high_voltage/spec/spec_helper.rb:4:in `<top (required)>'
    from /home/mike/thoughtbot/high_voltage/spec/controllers/pages_controller_spec.rb:3:in `require'
    from /home/mike/thoughtbot/high_voltage/spec/controllers/pages_controller_spec.rb:3:in `<top (required)>'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `load'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `block in load_spec_files'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `map'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `load_spec_files'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:18:in `run'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:80:in `run_in_process'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:69:in `run'
    from /home/mike/.rvm/gems/ruby-1.9.2-p320/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:11:in `block in autorun'
```
