### PR TITLE
autoload HighVoltage::PageFinder to avoid uninitialized constant error

### DIFF
--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,5 +1,3 @@
-require 'high_voltage/page_finder'
-
 class HighVoltage::PagesController < ApplicationController
   unloadable
   layout Proc.new { |_| HighVoltage.layout }

--- a/lib/high_voltage.rb
+++ b/lib/high_voltage.rb
@@ -15,4 +15,6 @@ module HighVoltage
   end
 
   require 'high_voltage/engine' if defined?(Rails)
+
+  autoload :PageFinder, 'high_voltage/page_finder'
 end


### PR DESCRIPTION
The following error raises every time after changing some files (or even just touching them, e.g., `touch app/controllers/application_controller.rb`) in my project and then visiting any static page without restarting the server:

```
NameError in HighVoltage::PagesController#show
uninitialized constant HighVoltage::PageFinder
```

I tried the following code in Rails console:

```
1.9.3p194 :002 > HighVoltage::PagesController
 => HighVoltage::PagesController 
1.9.3p194 :003 > HighVoltage::PageFinder
 => HighVoltage::PageFinder 
1.9.3p194 :004 > reload!
Reloading...
 => true 
1.9.3p194 :005 > HighVoltage::PagesController
 => HighVoltage::PagesController 
1.9.3p194 :006 > HighVoltage::PageFinder
NameError: uninitialized constant HighVoltage::PageFinder
    from (irb):6
    from /home/frozenmouse/.rvm/gems/ruby-1.9.3-p194@<my-project>/gems/railties-3.2.8/lib/rails/commands/console.rb:47:in `start'
    from /home/frozenmouse/.rvm/gems/ruby-1.9.3-p194@<my-project>/gems/railties-3.2.8/lib/rails/commands/console.rb:8:in `start'
    from /home/frozenmouse/.rvm/gems/ruby-1.9.3-p194@<my-project>/gems/railties-3.2.8/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```

It seems that PageFinder was not getting reloaded.

Using `autoload` in module `HighVoltage` works for me, and the `require` directive in `pages_controller.rb` is no longer needed. But I have no idea how to write test for this...
