### PR TITLE
Expose pages#show route via GET

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   if HighVoltage.routes
-    match "/#{HighVoltage.content_path}*id" => 'high_voltage/pages#show', :as => :page, :format => false
+    get "/#{HighVoltage.content_path}*id" => 'high_voltage/pages#show', :as => :page, :format => false
   end
 end


### PR DESCRIPTION
Hi there,

I noticed this when I tried adding high_voltage to a edge rails app:

A route defined with `#match` will raise a error message in edge rails if you haven't specified `:via => :get` or similair for that route. I changed the route setup to use `get` instead as (I guess) that is the only HTTP method that you want to use for static pages.  

See this commit on rails for more info on the error:
https://github.com/rails/rails/commit/56cdc81c08b1847c5c1f699810a8c3b9ac3715a6#LOL61

**I didn't add any tests for this** as I am unsure how to go about on those. All the current tests pass now. If I add a Gemfile that uses edge rails I guess the tests for ruby versions < 1.9.3 will break when that Gemfile is used? 

Let me know what you think, maybe this change should be saved until rails 4 is released? :neckbeard: 
