### PR TITLE
Minor README update for root path routes when overriding PagesController

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Override the default route:
     # in config/routes.rb
     match "/pages/*id" => 'pages#show', :as => :page, :format => false
 
+    # if routing the root path, update for your controller
+    root :to => 'pages#show', :id => 'home'
+
 Then modify it to subclass from High Voltage, adding whatever you need:
 
     class PagesController < HighVoltage::PagesController


### PR DESCRIPTION
A very minor update to the Overriding section reminding users to update their root route when overriding HighVoltage::PagesController.

This bit me for a few moments until I realized I was "Doing It Wrong™"; this change may save some hapless user 15 seconds or more of banging their head on their keyboard.

Cheers!
-Craig
