### PR TITLE
lib/high_voltage.rb should be able to be required.

### DIFF
--- a/lib/high_voltage.rb
+++ b/lib/high_voltage.rb
@@ -3,6 +3,7 @@ require 'high_voltage/constraints/root_route'
 require 'high_voltage/page_finder'
 require 'high_voltage/route_drawers/default'
 require 'high_voltage/route_drawers/root'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module HighVoltage
   mattr_accessor :layout

--- a/spec/high_voltage_spec.rb
+++ b/spec/high_voltage_spec.rb
@@ -1,7 +1,11 @@
-require 'spec_helper'
+require 'minimal_spec_helper'
 
 describe HighVoltage do
   it 'should be valid' do
     HighVoltage.should be_a(Module)
+  end
+
+  it 'should be loadable without preloading rails' do
+    expect { require 'high_voltage' }.not_to raise_error
   end
 end

--- a/spec/minimal_spec_helper.rb
+++ b/spec/minimal_spec_helper.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  require 'rspec/expectations'
+  config.include RSpec::Matchers
+  config.mock_with :rspec
+end


### PR DESCRIPTION
Currently the main library file `lib/high_voltage.rb` can't be required since it uses the `mattr_accessor` method from the `active_support` gem.

Requiring `high_voltage` results in the following error:

```
[1] pry(main)> require 'high_voltage'
NoMethodError: undefined method `mattr_accessor' for HighVoltage:Module
from /home/linduxed/Documents/thoughtbot/high_voltage/lib/high_voltage.rb:8:in `<module:HighVoltage>'
```

`require 'active_support/core_ext'` solves the problem, but might be loading too much.
