### PR TITLE
Use older version of capybara.

### DIFF
--- a/high_voltage.gemspec
+++ b/high_voltage.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("appraisal")
   s.add_development_dependency("rspec-rails")
-  # Ruby version < 1.9.3 can't install capybara > 2.0.3.
   s.add_development_dependency("capybara", "= 2.0.3")
   s.add_development_dependency("sqlite3")
 end


### PR DESCRIPTION
Ruby versions older than 1.9.3 can't use capybara > 2.0.3.

Travis-provided error:

   Gem::InstallError: capybara requires Ruby version >= 1.9.3.
   An error occurred while installing capybara (2.1.0), and Bundler
   cannot continue.
   Make sure that `gem install capybara -v '2.1.0'` succeeds before
   bundling.
