### PR TITLE
Fix problem if actionpack-action_caching is not installed

### DIFF
--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,13 +1,13 @@
 class HighVoltage::PagesController < ApplicationController
   layout Proc.new { |_| HighVoltage.layout }
 
-  caches_action :show, if: Proc.new {
-    HighVoltage.action_caching
-  }
+  if HighVoltage.action_caching
+    caches_action :show
+  end
 
-  caches_page :show, if: Proc.new {
-    HighVoltage.page_caching
-  }
+  if HighVoltage.page_caching
+    caches_page :show
+  end
 
   rescue_from ActionView::MissingTemplate do |exception|
     if exception.message =~ %r{Missing template #{page_finder.content_path}}


### PR DESCRIPTION
This error occurs if actionpack-action_caching is not installed:

```
ActionController::RoutingError (undefined method `caches_action' for HighVoltage::PagesController:Class)
```
