### PR TITLE
Update Ruby and Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
 gemfile:
   - gemfiles/rails_3.0.20.gemfile
   - gemfiles/rails_3.1.12.gemfile
   - gemfiles/rails_3.2.13.gemfile
-  - gemfiles/rails_4.0.0.rc1.gemfile
+  - gemfiles/rails_4.0.0.gemfile
 matrix:
   allow_failures:
-    - gemfile: gemfiles/rails_4.0.0.rc1.gemfile
+    - gemfile: gemfiles/rails_4.0.0.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
-['4.0.0.rc1', '3.2.13', '3.1.12', '3.0.20'].each do |rails_version|
+['4.0.0', '3.2.13', '3.1.12', '3.0.20'].each do |rails_version|
   appraise "rails_#{rails_version}" do
     gem "rails", rails_version
-    if rails_version == '4.0.0.rc1'
+    if rails_version == '4.0.0'
       gem "actionpack-action_caching"
       gem "actionpack-page_caching"
     end

--- a/gemfiles/rails_4.0.0.gemfile
+++ b/gemfiles/rails_4.0.0.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "4.0.0.rc1"
+gem "rails", "4.0.0"
 gem "actionpack-action_caching"
 gem "actionpack-page_caching"
 


### PR DESCRIPTION
- Remove Ruby 1.8.7 support
  http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
- Update Rails version to 4.0.0
  http://weblog.rubyonrails.org/2013/6/25/Rails-4-0-final/
