### PR TITLE
Drop Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
 gemfile:


### PR DESCRIPTION
In light of http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
we are dropping support for Ruby 1.8.7.
