### PR TITLE
Specify activesupport version for Ruby 1.9.2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,23 +6,11 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    actionpack (4.0.0)
-      activesupport (= 4.0.0)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
-      rack (~> 1.5.2)
-      rack-test (~> 0.6.2)
-    activesupport (4.0.0)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activesupport (3.1.12)
+      multi_json (~> 1.0)
     appraisal (0.5.2)
       bundler
       rake
-    atomic (1.1.10)
-    builder (3.1.4)
     capybara (2.0.3)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -40,14 +28,11 @@ GEM
       debugger-ruby_core_source (~> 1.2.3)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.2.3)
-    diff-lcs (1.2.4)
-    erubis (2.7.0)
+    diff-lcs (1.1.3)
     ffi (1.9.0)
-    i18n (0.6.4)
     method_source (0.8.1)
     mime-types (1.23)
     mini_portile (0.5.1)
-    minitest (4.7.5)
     multi_json (1.7.7)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
@@ -61,23 +46,17 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    railties (4.0.0)
-      actionpack (= 4.0.0)
-      activesupport (= 4.0.0)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
-    rspec-core (2.14.3)
-    rspec-expectations (2.14.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.1)
-    rspec-rails (2.14.0)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
+    rspec (2.1.0)
+      rspec-core (~> 2.1.0)
+      rspec-expectations (~> 2.1.0)
+      rspec-mocks (~> 2.1.0)
+    rspec-core (2.1.0)
+    rspec-expectations (2.1.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.1.0)
+    rspec-rails (2.1.0)
+      rspec (~> 2.1.0)
     rubyzip (0.9.9)
     selenium-webdriver (2.33.0)
       childprocess (>= 0.2.5)
@@ -85,11 +64,6 @@ GEM
       rubyzip
       websocket (~> 1.0.4)
     slop (3.4.5)
-    sqlite3 (1.3.7)
-    thor (0.18.1)
-    thread_safe (0.1.0)
-      atomic
-    tzinfo (0.3.37)
     websocket (1.0.7)
     xpath (1.0.0)
       nokogiri (~> 1.3)
@@ -98,9 +72,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (>= 3.1.0)
   appraisal
   capybara (= 2.0.3)
   high_voltage!
   pry-debugger
   rspec-rails
-  sqlite3

--- a/high_voltage.gemspec
+++ b/high_voltage.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_development_dependency("activesupport", ">= 3.1.0")
   s.add_development_dependency("appraisal")
   s.add_development_dependency("capybara", "= 2.0.3")
   s.add_development_dependency("pry-debugger")
   s.add_development_dependency("rspec-rails")
-  s.add_development_dependency("sqlite3")
 end


### PR DESCRIPTION
Fixes the issues with activesupport version and 1.9.2

https://travis-ci.org/thoughtbot/high_voltage/builds/9275646
