### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-language: ruby
+language:
+  - ruby
+install:
+  - 'bundle install'
 rvm:
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
Force `bundle install` in install step

Travis will now runs `bundle install --deployment` if it detects that
the project has `Gemfile.lock`. However, there's a problem in Bundler
deployment install that cause it not installing `bundler` gem into
`vendor/bundle` directory, which causes `require 'bundler'` to fail.
