### PR TITLE
Update README.md to include instruction to user to disable default routes when overriding with a local controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Disable the default routes:
 HighVoltage.routes = false
 ```
 
-Define new a route for the new `PagesController`:
+Define a new route for the local `PagesController`:
 
 ```ruby
 # config/routes.rb


### PR DESCRIPTION
This change simply reiterates the steps from the Disabling Routes section down into the Override section which is required to avoid errors due to routing collisions:  `Invalid route name, already in use: 'page'`.  Disabling the routes resolves this issue and allows the user to successfully override with a local controller. 
