### PR TITLE
Made HighVoltage.layout optional.

### DIFF
--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -2,7 +2,9 @@ module HighVoltage::StaticPage
   extend ActiveSupport::Concern
 
   included do
-    #layout ->(_) { layout }
+    if HighVoltage.layout
+      layout ->(_) { layout }
+    end
 
     rescue_from ActionView::MissingTemplate do |exception|
       if exception.message =~ %r{Missing template #{page_finder.content_path}}


### PR DESCRIPTION
Using the HV defined layout conflicts with any Application defined layout. The HV layout should only be used when defined, else, reverting back to standard rails layout..
