### PR TITLE
Refactor test suite to use expect syntax

### DIFF
--- a/spec/constraints/root_route_spec.rb
+++ b/spec/constraints/root_route_spec.rb
@@ -1,25 +1,21 @@
 require 'spec_helper'
 
 describe HighVoltage::Constraints::RootRoute, '.matches?' do
-  context 'view file exists' do
-    it 'should return true' do
-      request = double(path: 'index')
-      Dir.stub(:glob).and_return(['about.html.erb'])
+  it 'returns true when the view file exists' do
+    request = double(path: 'index')
+    Dir.stub(:glob).and_return(['about.html.erb'])
 
-      result = HighVoltage::Constraints::RootRoute.matches?(request)
+    result = HighVoltage::Constraints::RootRoute.matches?(request)
 
-      expect(result).to be_true
-    end
+    expect(result).to be_true
   end
 
-  context 'view file does not exist' do
-    it 'should return false' do
-      request = double(path: 'index')
-      File.stub(:glob).and_return([])
+  it 'returns false when the view files does not exist' do
+    request = double(path: 'index')
+    File.stub(:glob).and_return([])
 
-      result = HighVoltage::Constraints::RootRoute.matches?(request)
+    result = HighVoltage::Constraints::RootRoute.matches?(request)
 
-      expect(result).to be_false
-    end
+    expect(result).to be_false
   end
 end

--- a/spec/controllers/alternative_finder_controller_spec.rb
+++ b/spec/controllers/alternative_finder_controller_spec.rb
@@ -6,7 +6,7 @@ describe AlternativeFinderController do
   it 'renders the file from the alternative directory' do
     get :show, :id => 'ebg13'
 
-    response.should be_success
-    response.should render_template('rot13')
+    expect(response).to be_success
+    expect(response).to render_template('rot13')
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -7,44 +7,38 @@ describe HighVoltage::PagesController do
     describe 'on GET to /pages/exists' do
       before { get :show, :id => 'exists' }
 
-      it 'should respond with success and render template' do
-        response.should be_success
-        response.should render_template('exists')
+      it 'responds with success and render template' do
+        expect(response).to be_success
+        expect(response).to render_template('exists')
       end
 
-      it 'should use the default layout used by ApplicationController' do
-        response.should render_template('layouts/application')
+      it 'uses the default layout used by ApplicationController' do
+        expect(response).to render_template('layouts/application')
       end
     end
 
     describe 'on GET to /pages/dir/nested' do
       before { get :show, :id => 'dir/nested' }
 
-      it 'should respond with success and render template' do
-        response.should be_success
-        response.should render_template('pages/dir/nested')
+      it 'responds with success and render template' do
+        expect(response).to be_success
+        expect(response).to render_template('pages/dir/nested')
       end
     end
 
-    it 'should raise a routing error for an invalid page' do
-      lambda {
-        get :show,
-        :id => 'invalid'
-      }.should raise_error(ActionController::RoutingError)
+    it 'raises a routing error for an invalid page' do
+      expect { get :show, id: 'invalid' }
+        .to raise_error(ActionController::RoutingError)
     end
 
-    it 'should raise a routing error for a page in another directory' do
-      lambda {
-        get :show,
-        :id => '../other/wrong'
-      }.should raise_error(ActionController::RoutingError)
+    it 'raises a routing error for a page in another directory' do
+      expect { get :show, id: '../other/wrong' }
+        .to raise_error(ActionController::RoutingError)
     end
 
-    it 'should raise missing template error for valid page with invalid partial' do
-      lambda {
-        get :show,
-        :id => 'exists_but_references_nonexistent_partial'
-      }.should raise_error(ActionView::MissingTemplate)
+    it 'raises a missing template error for valid page with invalid partial' do
+      expect { get :show, id: 'exists_but_references_nonexistent_partial' }
+        .to raise_error(ActionView::MissingTemplate)
     end
   end
 
@@ -56,9 +50,9 @@ describe HighVoltage::PagesController do
     describe 'on GET to /pages/exists' do
       before { get :show, :id => 'exists' }
 
-      it 'should use the custom configured layout' do
-        response.should_not render_template('layouts/application')
-        response.should render_template('layouts/alternate')
+      it 'uses the custom configured layout' do
+        expect(response).not_to render_template('layouts/application')
+        expect(response).to render_template('layouts/alternate')
       end
     end
   end
@@ -72,47 +66,43 @@ describe HighVoltage::PagesController do
     describe 'on GET to /other_pages/also_exists' do
       before { get :show, :id => 'also_exists' }
 
-      it 'should respond with success and render template' do
-        response.should be_success
-        response.should render_template('other_pages/also_exists')
+      it 'responds with success and render template' do
+        expect(response).to be_success
+        expect(response).to render_template('other_pages/also_exists')
       end
     end
 
     describe 'on GET to /other_pages/also_dir/nested' do
       before { get :show, :id => 'also_dir/also_nested' }
 
-      it 'should respond with success and render template' do
-        response.should be_success
-        response.should render_template('other_pages/also_dir/also_nested')
+      it 'responds with success and render template' do
+        expect(response).to be_success
+        expect(response).to render_template('other_pages/also_dir/also_nested')
       end
     end
 
-    it 'should raise a routing error for an invalid page' do
-      lambda {
-        get :show,
-        :id => 'also_invalid'
-      }.should raise_error(ActionController::RoutingError)
+    it 'raises a routing error for an invalid page' do
+      expect { get :show, id: 'also_invalid' }
+        .to raise_error(ActionController::RoutingError)
     end
 
-    it 'should raise a routing error for a page in another directory' do
-      lambda {
-        get :show,
-        :id => '../other/wrong'
-      }.should raise_error(ActionController::RoutingError)
+    context 'page in another directory' do
+      it 'raises a routing error' do
+        expect { get :show, id: '../other_wrong' }
+          .to raise_error(ActionController::RoutingError)
+      end
+
+      it 'raises a routing error when using a Unicode exploit' do
+        expect { get :show, id: '/\\../other/wrong' }
+          .to raise_error(ActionController::RoutingError)
+      end
     end
 
-    it 'should raise a routing error for a page in another directory when using a Unicode exploit' do
-      lambda {
-        get :show,
-        :id => '/\\../other/wrong'
-      }.should raise_error(ActionController::RoutingError)
-    end
+    it 'raises a missing template error for valid page with invalid partial' do
+      id = 'also_exists_but_references_nonexistent_partial'
 
-    it 'should raise missing template error for valid page with invalid partial' do
-      lambda {
-        get :show,
-        :id => 'also_exists_but_references_nonexistent_partial'
-      }.should raise_error(ActionView::MissingTemplate)
+      expect { get :show, id: id }
+        .to raise_error(ActionView::MissingTemplate)
     end
   end
 end

--- a/spec/controllers/subclassed_pages_controller_spec.rb
+++ b/spec/controllers/subclassed_pages_controller_spec.rb
@@ -6,35 +6,29 @@ describe SubclassedPagesController do
   describe 'on GET to /subclassed_pages/also_exists' do
     before { get :show, :id => 'also_exists' }
 
-    it 'should respond with success and render template' do
-      response.should be_success
-      response.should render_template('also_exists')
+    it 'responds with success and render template' do
+      expect(response).to be_succes
+      expect(response).to render_template('also_exists')
     end
 
-    it 'should use the custom configured layout' do
-      response.should_not render_template('layouts/application')
-      response.should render_template('layouts/alternate')
+    it 'uses the custom configured layout' do
+      expect(response).not_to render_template('layouts/application')
+      expect(response).to render_template('layouts/alternate')
     end
   end
 
-  it 'should raise a routing error for an invalid page' do
-    lambda {
-      get :show,
-      :id => 'invalid'
-    }.should raise_error(ActionController::RoutingError)
+  it 'raises a routing error for an invalid page' do
+    expect { get :show, id: 'invalid' }
+      .to raise_error(ActionController::RoutingError)
   end
 
-  it 'should raise a routing error for a page in another directory' do
-    lambda {
-      get :show,
-      :id => '../other/wrong'
-    }.should raise_error(ActionController::RoutingError)
+  it 'raises a routing error for a page in another directory' do
+    expect { get :show, id: '../other/wrong' }
+      .to raise_error(ActionController::RoutingError)
   end
 
-  it 'should raise missing template error for valid page with invalid partial' do
-    lambda {
-      get :show,
-      :id => 'also_exists_but_references_nonexistent_partial'
-    }.should raise_error(ActionView::MissingTemplate)
+  it 'raises a missing template error for valid page with invalid partial' do
+    expect { get :show, id: 'also_exists_but_references_nonexistent_partial' }
+      .to raise_error(ActionView::MissingTemplate)
   end
 end

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -2,22 +2,22 @@ require 'spec_helper'
 
 describe HighVoltage::PageFinder do
   it 'produces the name of an existing template' do
-    find('existing').should eq 'pages/existing'
+    expect(find('existing')).to eq 'pages/existing'
   end
 
   it 'produces the name of a nested template' do
-    find('dir/nested').should eq 'pages/dir/nested'
+    expect(find('dir/nested')).to eq 'pages/dir/nested'
   end
 
   it 'uses a custom content path' do
     with_content_path('other_pages/') do
-      find('also_exists').should eq 'other_pages/also_exists'
+      expect(find('also_exists')).to eq 'other_pages/also_exists'
     end
   end
 
   it 'exposes the content path' do
     with_content_path('another_thing/') do
-      page_finder.content_path.should eq 'another_thing/'
+      expect(page_finder.content_path).to eq 'another_thing/'
     end
   end
 
@@ -28,7 +28,7 @@ describe HighVoltage::PageFinder do
       end
     end
 
-    subclass.new('sweet page').page_name.should eq 'the page is sweet page'
+    expect(subclass.new('sweet page').page_name).to eq 'the page is sweet page'
   end
 
   private

--- a/spec/high_voltage_spec.rb
+++ b/spec/high_voltage_spec.rb
@@ -1,11 +1,11 @@
 require 'minimal_spec_helper'
 
 describe HighVoltage do
-  it 'should be valid' do
-    HighVoltage.should be_a(Module)
+  it 'is valid' do
+    expect(HighVoltage).to be_a(Module)
   end
 
-  it 'should be loadable without preloading rails' do
+  it 'is loadable without preloading rails' do
     expect { require 'high_voltage' }.not_to raise_error
   end
 end

--- a/spec/integration/navigation_spec.rb
+++ b/spec/integration/navigation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Navigation' do
   include Capybara::DSL
 
-  it 'should be a valid app' do
-    ::Rails.application.should be_a(Dummy::Application)
+  it 'is a valid app' do
+    expect(::Rails.application).to be_a(Dummy::Application)
   end
 end

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe 'routes' do
   context 'default configuration' do
     it 'generates a route' do
-      page_path('one').should eq '/pages/one'
+      expect(page_path('one')).to eq '/pages/one'
     end
 
     it 'generates a nested route' do
-      page_path('one/two').should eq '/pages/one/two'
+      expect(page_path('one/two')).to eq '/pages/one/two'
     end
 
     it 'recognizes a route' do
@@ -51,11 +51,11 @@ describe 'routes' do
     end
 
     it 'generates a route' do
-      page_path('one').should eq '/one'
+      expect(page_path('one')).to eq '/one'
     end
 
     it 'generates  a nested route' do
-      page_path('one/two').should eq '/one/two'
+      expect(page_path('one/two')).to eq '/one/two'
     end
   end
 
@@ -66,11 +66,11 @@ describe 'routes' do
     end
 
     it 'generates a route' do
-      page_path('one').should eq '/other_pages/one'
+      expect(page_path('one')).to eq '/other_pages/one'
     end
 
     it 'generates a nested route' do
-      page_path('one/two').should eq '/other_pages/one/two'
+      expect(page_path('one/two')).to eq '/other_pages/one/two'
     end
 
     it 'recognizes a route' do
@@ -125,7 +125,7 @@ describe 'routes' do
 
   context 'no home page route' do
     it 'does generate a home page route' do
-      { :get => '/' }.should_not be_routable
+      expect(get: '/').not_to be_routable
     end
   end
 
@@ -134,7 +134,7 @@ describe 'routes' do
       HighVoltage.routes = false
       Rails.application.reload_routes!
 
-      { :get => '/pages/one/two' }.should_not be_routable
+      expect(get: '/pages/one/two').not_to be_routable
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
     Rails.application.reload_routes!
   end
 
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
   config.include RSpec::Matchers
   config.mock_with :rspec
   config.order = 'random'


### PR DESCRIPTION
Use the expect syntax in favor of the should syntax consistently
throughout HighVoltage.

Removes any 'should' prefixes in `it` descriptions.

Require expect syntax
