### PR TITLE
Handle bundle install failures with travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language:
   - ruby
 install:
-  - 'bundle install'
+  - 'travis_retry bundle install'
 rvm:
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
Resolve timeout issues when running bundle install on Travis by using
the `travis_retry` command. It will retry the install command up to 3
times.
