### PR TITLE
Bump to version 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    high_voltage (2.2.0)
+    high_voltage (2.2.1)
 
 GEM
   remote: http://rubygems.org/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+New for 2.2.1:
++ Resolve issue with require statements for Rails 3.x projects
+
 New for 2.2.0:
 + Deprecate caching because page and action caching was removed in Rails 4
 + Refactor test suite to use rspec `expect` syntax consistently.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Yeah, like "About us", "Directions", marketing pages, etc.
 Include in your Gemfile:
 
 ```ruby
-gem 'high_voltage', '~> 2.2.0'
+gem 'high_voltage', '~> 2.2.1'
 ```
 
 For Rails versions prior to 3.0, use the 0.9.2 tag of high_voltage:

--- a/lib/high_voltage/version.rb
+++ b/lib/high_voltage/version.rb
@@ -1,3 +1,3 @@
 module HighVoltage
-  VERSION = '2.2.0'.freeze
+  VERSION = "2.2.1".freeze
 end


### PR DESCRIPTION
@dgalarza quick one to bump the version to `2.2.1` do you think its worth yanking `2.2.0` from Rubygems?

Updated the version and NEWS file. This cut should fix the loading issues users are experiencing with Rails 3.x
