### PR TITLE
Change description on homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: High Voltage
 description: >
-  High Voltage is the most rapid tool to serve static pages in your rails app
+  High Voltage serves static pages in your Rails app
 url: "http://thoughtbot.github.io/high_voltage/"
 repository_url: "http://github.com/thoughtbot/high_voltage"
 documentation_url: "http://github.com/thoughtbot/high_voltage/blob/master/README.md"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,6 +15,6 @@
   <h1 class="site-title">
     {% include high_voltage-logo.svg %}
   </h1>
-  <p class="site-description">High Voltage is the most rapid tool to serve static pages in your Rails app</p>
+  <p class="site-description">High Voltage serves static pages in your Rails app</p>
 
 </header>


### PR DESCRIPTION
High Voltage isn't particularly rapid (but it is easy to use). I "the most rapid tool" reads oddly, as well, so I stripped it down to a simple description.
