### PR TITLE
Raise routing errors for invalid or empty page ids

### DIFF
--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -6,11 +6,13 @@ module HighVoltage::StaticPage
 
     rescue_from ActionView::MissingTemplate do |exception|
       if exception.message =~ %r{Missing template #{page_finder.content_path}}
-        raise ActionController::RoutingError, "No such page: #{params[:id]}"
+        invalid_page
       else
         raise exception
       end
     end
+
+    rescue_from HighVoltage::InvalidPageIdError, with: :invalid_page
 
     if respond_to?(:caches_action)
       caches_action :show, layout: HighVoltage.action_caching_layout,
@@ -38,5 +40,9 @@ module HighVoltage::StaticPage
 
   def page_finder_factory
     HighVoltage::PageFinder
+  end
+
+  def invalid_page
+    raise ActionController::RoutingError, "No such page: #{params[:id]}"
   end
 end

--- a/lib/high_voltage/page_finder.rb
+++ b/lib/high_voltage/page_finder.rb
@@ -31,7 +31,13 @@ module HighVoltage
     end
 
     def clean_id
-      @page_id.tr("^#{VALID_CHARACTERS}", '')
+      @page_id.tr("^#{VALID_CHARACTERS}", "").tap do |id|
+        if id.blank?
+          raise InvalidPageIdError.new "Invalid page id: #{@page_id}"
+        end
+      end
     end
   end
+
+  class InvalidPageIdError < StandardError; end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,108 +1,113 @@
-require 'spec_helper'
+# encoding: utf-8
+
+require "spec_helper"
 
 describe HighVoltage::PagesController do
   render_views
 
-  context 'using default configuration' do
-    describe 'on GET to /pages/exists' do
-      before { get :show, :id => 'exists' }
+  context "using default configuration" do
+    describe "on GET to /pages/exists" do
+      before { get :show, id: "exists" }
 
-      it 'responds with success and render template' do
+      it "responds with success and render template" do
         expect(response).to be_success
-        expect(response).to render_template('exists')
+        expect(response).to render_template("exists")
       end
 
-      it 'uses the default layout used by ApplicationController' do
-        expect(response).to render_template('layouts/application')
+      it "uses the default layout used by ApplicationController" do
+        expect(response).to render_template("layouts/application")
       end
     end
 
-    describe 'on GET to /pages/dir/nested' do
-      before { get :show, :id => 'dir/nested' }
+    describe "on GET to /pages/dir/nested" do
+      before { get :show, id: "dir/nested" }
 
-      it 'responds with success and render template' do
+      it "responds with success and render template" do
         expect(response).to be_success
-        expect(response).to render_template('pages/dir/nested')
+        expect(response).to render_template("pages/dir/nested")
       end
     end
 
-    it 'raises a routing error for an invalid page' do
-      expect { get :show, id: 'invalid' }
-        .to raise_error(ActionController::RoutingError)
+    it "raises a routing error for an invalid page" do
+      expect { get :show, id: "invalid" }.
+        to raise_error(ActionController::RoutingError)
     end
 
-    it 'raises a routing error for a page in another directory' do
-      expect { get :show, id: '../other/wrong' }
-        .to raise_error(ActionController::RoutingError)
+    it "raises a routing error for a page in another directory" do
+      expect { get :show, id: "../other/wrong" }.
+        to raise_error(ActionController::RoutingError)
     end
 
-    it 'raises a missing template error for valid page with invalid partial' do
-      expect { get :show, id: 'exists_but_references_nonexistent_partial' }
-        .to raise_error(ActionView::MissingTemplate)
+    it "raises a missing template error for valid page with invalid partial" do
+      expect { get :show, id: "exists_but_references_nonexistent_partial" }.
+        to raise_error(ActionView::MissingTemplate)
     end
   end
 
-  context 'using custom layout' do
+  context "using custom layout" do
     before(:each) do
-      HighVoltage.layout = 'alternate'
+      HighVoltage.layout = "alternate"
     end
 
-    describe 'on GET to /pages/exists' do
-      before { get :show, :id => 'exists' }
+    describe "on GET to /pages/exists" do
+      before { get :show, id: "exists" }
 
-      it 'uses the custom configured layout' do
-        expect(response).not_to render_template('layouts/application')
-        expect(response).to render_template('layouts/alternate')
+      it "uses the custom configured layout" do
+        expect(response).not_to render_template("layouts/application")
+        expect(response).to render_template("layouts/alternate")
       end
     end
   end
 
-  context 'using custom content path' do
+  context "using custom content path" do
     before(:each) do
-      HighVoltage.content_path = 'other_pages/'
+      HighVoltage.content_path = "other_pages/"
       Rails.application.reload_routes!
     end
 
-    describe 'on GET to /other_pages/also_exists' do
-      before { get :show, :id => 'also_exists' }
+    describe "on GET to /other_pages/also_exists" do
+      before { get :show, id: "also_exists" }
 
-      it 'responds with success and render template' do
+      it "responds with success and render template" do
         expect(response).to be_success
-        expect(response).to render_template('other_pages/also_exists')
+        expect(response).to render_template("other_pages/also_exists")
       end
     end
 
-    describe 'on GET to /other_pages/also_dir/nested' do
-      before { get :show, :id => 'also_dir/also_nested' }
+    describe "on GET to /other_pages/also_dir/nested" do
+      before { get :show, id: "also_dir/also_nested" }
 
-      it 'responds with success and render template' do
+      it "responds with success and render template" do
         expect(response).to be_success
-        expect(response).to render_template('other_pages/also_dir/also_nested')
+        expect(response).to render_template("other_pages/also_dir/also_nested")
       end
     end
 
-    it 'raises a routing error for an invalid page' do
-      expect { get :show, id: 'also_invalid' }
-        .to raise_error(ActionController::RoutingError)
+    it "raises a routing error for an invalid page" do
+      expect { get :show, id: "also_invalid" }.
+        to raise_error(ActionController::RoutingError)
+
+      expect { get :show, id: "√®ø" }.
+        to raise_error(ActionController::RoutingError)
     end
 
-    context 'page in another directory' do
-      it 'raises a routing error' do
-        expect { get :show, id: '../other_wrong' }
-          .to raise_error(ActionController::RoutingError)
+    context "page in another directory" do
+      it "raises a routing error" do
+        expect { get :show, id: "../other_wrong" }.
+          to raise_error(ActionController::RoutingError)
       end
 
-      it 'raises a routing error when using a Unicode exploit' do
-        expect { get :show, id: '/\\../other/wrong' }
-          .to raise_error(ActionController::RoutingError)
+      it "raises a routing error when using a Unicode exploit" do
+        expect { get :show, id: "/\\../other/wrong" }.
+          to raise_error(ActionController::RoutingError)
       end
     end
 
-    it 'raises a missing template error for valid page with invalid partial' do
-      id = 'also_exists_but_references_nonexistent_partial'
+    it "raises a missing template error for valid page with invalid partial" do
+      id = "also_exists_but_references_nonexistent_partial"
 
-      expect { get :show, id: id }
-        .to raise_error(ActionView::MissingTemplate)
+      expect { get :show, id: id }.
+        to raise_error(ActionView::MissingTemplate)
     end
   end
 end

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -1,34 +1,44 @@
-require 'spec_helper'
+# encoding: utf-8
+
+require "spec_helper"
 
 describe HighVoltage::PageFinder do
-  it 'produces the name of an existing template' do
-    expect(find('existing')).to eq 'pages/existing'
+  it "produces the name of an existing template" do
+    expect(find("existing")).to eq "pages/existing"
   end
 
-  it 'produces the name of a nested template' do
-    expect(find('dir/nested')).to eq 'pages/dir/nested'
+  it "produces the name of a nested template" do
+    expect(find("dir/nested")).to eq "pages/dir/nested"
   end
 
-  it 'uses a custom content path' do
-    with_content_path('other_pages/') do
-      expect(find('also_exists')).to eq 'other_pages/also_exists'
+  it "uses a custom content path" do
+    with_content_path("other_pages/") do
+      expect(find("also_exists")).to eq "other_pages/also_exists"
     end
   end
 
-  it 'exposes the content path' do
-    with_content_path('another_thing/') do
-      expect(page_finder.content_path).to eq 'another_thing/'
+  it "exposes the content path" do
+    with_content_path("another_thing/") do
+      expect(page_finder.content_path).to eq "another_thing/"
     end
   end
 
-  it 'provides the page_id' do
+  it "provides the page_id" do
     subclass = Class.new(HighVoltage::PageFinder) do
       def page_name
         "the page is #{page_id}"
       end
     end
 
-    expect(subclass.new('sweet page').page_name).to eq 'the page is sweet page'
+    expect(subclass.new("sweet page").page_name).to eq "the page is sweet page"
+  end
+
+  it "removes invalid characters from the page_id" do
+    expect(find("b\\a…d√")).to eq "pages/bad"
+  end
+
+  it "throws an exception if the page_id is empty after sanitization" do
+    expect { find("\\…√") }.to raise_error HighVoltage::InvalidPageIdError
   end
 
   private
@@ -37,7 +47,7 @@ describe HighVoltage::PageFinder do
     page_finder(page_id).find
   end
 
-  def page_finder(page_id = 'whatever')
+  def page_finder(page_id = "whatever")
     HighVoltage::PageFinder.new(page_id)
   end
 


### PR DESCRIPTION
Visiting page_ids made entirely up of invalid characters gets sanitised into an empty string, so it looks for a template called "pages/". This raises a missing template error (because it doesn't match the regex checking that it isn't a missing partial).

This commit adds a check to see if the page_id is empty after sanitisation, and raises and error if it is -- which is caught and turned into a routing error.