### PR TITLE
Allows to set parent application controller

### DIFF
--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -2,7 +2,6 @@ module HighVoltage::StaticPage
   extend ActiveSupport::Concern
 
   included do
-    layout ->(_) { HighVoltage.layout }
 
     rescue_from ActionView::MissingTemplate do |exception|
       if exception.message =~ %r{Missing template #{page_finder.content_path}}

--- a/app/controllers/high_voltage/pages_controller.rb
+++ b/app/controllers/high_voltage/pages_controller.rb
@@ -1,3 +1,3 @@
-class HighVoltage::PagesController < ApplicationController
+class HighVoltage::PagesController < HighVoltage.parent_controller.constantize
   include HighVoltage::StaticPage
 end

--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -8,10 +8,10 @@ module HighVoltage
     attr_accessor(
       :content_path,
       :home_page,
-      :layout,
       :parent_engine,
       :route_drawer,
       :routes,
+      :parent_controller
     )
 
     attr_reader :action_caching, :action_caching_layout, :page_caching
@@ -46,9 +46,9 @@ module HighVoltage
 
       self.content_path = 'pages/'
       self.home_page = nil
-      self.layout = 'application'
       self.route_drawer = HighVoltage::RouteDrawers::Default
       self.routes = true
+      self.parent_controller = 'AppliationController'
     end
   end
 end


### PR DESCRIPTION
Sometimes our ApplicatioinController will do some extra before_filter that we don't want from hight voltage, so set parent controller is a good idea than only layout.