### PR TITLE
Cache Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ rvm:
   - 2.0.0
   - 2.1.5
 script: 'bundle exec rake spec'
+sudo: false
+cache: bundler


### PR DESCRIPTION
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

With Container based CI, public projects can cache the results of bundle
install