### PR TITLE
Fixes file extension issue

### DIFF
--- a/lib/high_voltage/page_finder.rb
+++ b/lib/high_voltage/page_finder.rb
@@ -32,10 +32,14 @@ module HighVoltage
 
     def clean_id
       @page_id.tr("^#{VALID_CHARACTERS}", "").tap do |id|
-        if id.blank? || id.first == "."
+        if invalid_page_id?(id)
           raise InvalidPageIdError.new "Invalid page id: #{@page_id}"
         end
       end
+    end
+
+    def invalid_page_id?(id)
+      id.blank? || (id.first == ".")
     end
   end
 

--- a/lib/high_voltage/page_finder.rb
+++ b/lib/high_voltage/page_finder.rb
@@ -32,7 +32,7 @@ module HighVoltage
 
     def clean_id
       @page_id.tr("^#{VALID_CHARACTERS}", "").tap do |id|
-        if id.blank?
+        if id.blank? || id.first == "."
           raise InvalidPageIdError.new "Invalid page id: #{@page_id}"
         end
       end

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -42,7 +42,7 @@ describe HighVoltage::PageFinder do
   end
 
   it "throws an exception if the page_id is just a file extension after sanitization" do
-    expect { find("\\…√.zip") }.to raise_error HighVoltage::InvalidPageIdError
+    expect { find("\\√.zip") }.to raise_error HighVoltage::InvalidPageIdError
   end
 
   private

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -37,12 +37,14 @@ describe HighVoltage::PageFinder do
     expect(find("b\\a…d√")).to eq "pages/bad"
   end
 
-  it "throws an exception if the page_id is empty after sanitization" do
-    expect { find("\\…√") }.to raise_error HighVoltage::InvalidPageIdError
-  end
+  context "sanitized page_id" do
+    it "throws an exception if the page_id is empty" do
+      expect { find("\\…√") }.to raise_error HighVoltage::InvalidPageIdError
+    end
 
-  it "throws an exception if the page_id is just a file extension after sanitization" do
-    expect { find("\\√.zip") }.to raise_error HighVoltage::InvalidPageIdError
+    it "throws an exception if the page_id is just a file extension" do
+      expect { find("\\√.zip") }.to raise_error HighVoltage::InvalidPageIdError
+    end
   end
 
   private

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -41,6 +41,10 @@ describe HighVoltage::PageFinder do
     expect { find("\\…√") }.to raise_error HighVoltage::InvalidPageIdError
   end
 
+  it "throws an exception if the page_id is just a file extension after sanitization" do
+    expect { find("\\…√.zip") }.to raise_error HighVoltage::InvalidPageIdError
+  end
+
   private
 
   def find(page_id)


### PR DESCRIPTION
Visiting page_ids made of invalid characters followed by a file extension, or even just the file extension itself,  doesn't raise an InvalidPageIdError. This pr fixes that. It is closely related to this [pr](https://github.com/thoughtbot/high_voltage/pull/178) a few weeks back.