### PR TITLE
Getting a list of pages (for sitemaps, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 *.swp
 *.gem
 gemfiles/*.lock
+spec/fixtures/log/*.log

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ link_to 'Q4 Reports', page_path('about/corporate/policies/HR/en_US/biz/sales/Qua
 
 Bam.
 
+You can also get a list of your static pages by calling `HighVoltage.page_ids`
+This might be useful if you need to build a sitemap. For example, if you are
+using the [sitemap_generator](https://github.com/kjvarga/sitemap_generator) gem,
+you could add something like this to your sitemap config file:
+
+```ruby
+HighVoltage.page_ids.each do |page|
+  add page, changefreq: 'monthly'
+end
+```
+
 ## Configuration
 
 #### Routing overview

--- a/lib/high_voltage.rb
+++ b/lib/high_voltage.rb
@@ -3,6 +3,8 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 require 'high_voltage/configuration'
 require 'high_voltage/constraints/root_route'
+require "high_voltage/page"
+require "high_voltage/page_collector"
 require 'high_voltage/page_finder'
 require 'high_voltage/route_drawers/default'
 require 'high_voltage/route_drawers/root'

--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -45,6 +45,14 @@ module HighVoltage
       @page_caching = value
     end
 
+    def page_ids
+      HighVoltage::PageCollector.new(HighVoltage.full_path).page_ids
+    end
+
+    def full_path
+      Rails.root.join("app", "views", HighVoltage.content_path)
+    end
+
     def set_default_configuration
       @action_caching = false
       @action_caching_layout = true

--- a/lib/high_voltage/page.rb
+++ b/lib/high_voltage/page.rb
@@ -1,0 +1,44 @@
+module HighVoltage
+  class Page
+    attr_reader :content_path, :file_path
+
+    def initialize(content_path, file_path)
+      @content_path = content_path
+      @file_path = file_path
+    end
+
+    def id
+      file_path.gsub(content_path, "").gsub(html_file_pattern, "")
+    end
+
+    def valid?
+      exists? && file_in_content_path? && !directory? && !partial? && html?
+    end
+
+    private
+
+    def exists?
+      File.exists?(file_path)
+    end
+
+    def file_in_content_path?
+      file_path.start_with?(content_path)
+    end
+
+    def directory?
+      FileTest.directory?(file_path)
+    end
+
+    def partial?
+      File.basename(file_path).first == "_"
+    end
+
+    def html?
+      !file_path.match(html_file_pattern).nil?
+    end
+
+    def html_file_pattern
+      /\.(html)(\.[a-z]+)?$/
+    end
+  end
+end

--- a/lib/high_voltage/page_collector.rb
+++ b/lib/high_voltage/page_collector.rb
@@ -1,0 +1,23 @@
+module HighVoltage
+  require "find"
+
+  class PageCollector
+    attr_reader :content_path
+
+    def initialize(content_path)
+      @content_path = content_path.to_s
+    end
+
+    def page_ids
+      pages.select(&:valid?).map(&:id)
+    end
+
+    private
+
+    def pages
+      Find.find(content_path).map do |file_path|
+        HighVoltage::Page.new(content_path, file_path)
+      end
+    end
+  end
+end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -6,13 +6,10 @@ end
 module Dummy
   class Application < Rails::Application
     config.secret_key_base = "test"
-    config.paths["public"] = ["spec/fixtures/public"]
-    config.paths["config/routes.rb"] = ["spec/fixtures/config/routes.rb"]
-    config.paths["app/views"] = ["spec/fixtures/app/views"]
-    config.paths["app/controllers"] = ["spec/support/app/controllers"]
     config.eager_load = false
     config.action_controller.perform_caching = true
     config.action_controller.cache_store = :memory_store
+    config.root = "spec/fixtures"
   end
 end
 Dummy::Application.initialize!

--- a/spec/fixtures/app/views/pages/_partial.html.erb
+++ b/spec/fixtures/app/views/pages/_partial.html.erb
@@ -1,0 +1,1 @@
+partial

--- a/spec/fixtures/app/views/pages/text.txt.erb
+++ b/spec/fixtures/app/views/pages/text.txt.erb
@@ -1,0 +1,1 @@
+text page

--- a/spec/high_voltage/page_collector_spec.rb
+++ b/spec/high_voltage/page_collector_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe HighVoltage::PageCollector do
+  it "produces an array of all page_ids under pages/" do
+    expect(HighVoltage.page_ids).to eq [
+      "also_dir/also_nested",
+      "also_exists",
+      "also_exists_but_references_nonexistent_partial",
+      "dir/nested",
+      "exists",
+      "exists_but_references_nonexistent_partial",
+      "rot13"
+    ]
+  end
+
+  it "produces an array of all page_ids under other_pages/" do
+    with_content_path("other_pages/") do
+      expect(HighVoltage.page_ids).to eq [
+        "also_dir/also_nested",
+        "also_exists",
+        "also_exists_but_references_nonexistent_partial",
+      ]
+    end
+  end
+
+  private
+
+  def with_content_path(path)
+    original_content_path = HighVoltage.content_path
+    HighVoltage.content_path = path
+
+    yield
+
+    HighVoltage.content_path = original_content_path
+  end
+end

--- a/spec/high_voltage/page_spec.rb
+++ b/spec/high_voltage/page_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+describe HighVoltage::Page do
+  it "produces the id for a page" do
+    page = page(full_file_path("exists.html.erb"))
+
+    expect(page.id).to eq "exists"
+  end
+
+  it "produces the id for a page in a subdirectory" do
+    page = page(full_file_path("dir/nested.html.erb"))
+
+    expect(page.id).to eq "dir/nested"
+  end
+
+  it "is valid for a page" do
+    page = page(full_file_path("exists.html.erb"))
+
+    expect(page).to be_valid
+  end
+
+  it "is valid for a page in a subdirectory" do
+    page = page(full_file_path("dir/nested.html.erb"))
+
+    expect(page).to be_valid
+  end
+
+  it "is invalid for a directory" do
+    page = page(full_file_path("dir"))
+
+    expect(page).to_not be_valid
+  end
+
+  it "is invalid for a partial" do
+    page = page(full_file_path("_partial.html.erb"))
+
+    expect(page).to_not be_valid
+  end
+
+  it "is invalid for a non-existent page" do
+    page = page(full_file_path("nonexistent.html.erb"))
+
+    expect(page).to_not be_valid
+  end
+
+  it "is invalid for a text page" do
+    page = page(full_file_path("text.txt.erb"))
+
+    expect(page).to_not be_valid
+  end
+
+  private
+
+  def full_content_path
+    HighVoltage.full_path.to_s
+  end
+
+  def page(file_path)
+    HighVoltage::Page.new(full_content_path, file_path)
+  end
+
+  def full_file_path(file_path)
+    "#{full_content_path}#{file_path}"
+  end
+end


### PR DESCRIPTION
Here's my take on getting a list of High Voltage pages for building sitemaps, based on this issue: https://github.com/thoughtbot/high_voltage/issues/123

If you're using the sitemap_generator gem, you could do something like this in your config:

```
HighVoltage.page_ids.each do |page|
  add page, changefreq: 'monthly'
end
```