### PR TITLE
fix exception handling for special characters only pages

### DIFF
--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -5,7 +5,7 @@ module HighVoltage::StaticPage
     layout ->(_) { HighVoltage.layout }
 
     rescue_from ActionView::MissingTemplate do |exception|
-      if exception.message =~ %r{Missing template #{page_finder.content_path}}
+      if exception.message =~ %r{Missing template /*#{page_finder.content_path.gsub(/\//, '')}}
         invalid_page
       else
         raise exception


### PR DESCRIPTION
When I try to access a page with special characters in the url, they are stripped as its supposed to be, but then the exception message is a little different.
For example try to open  http://localhost:3000/яжш
the exception will be: 'Missing template /pages with {:locale=>[:en].........'  and page_finder.content_path will be 'pages/' so invalid_page wont be called as it should be.
I was trying to do more proper fix, but it looks like its something internal for rails to change the path in the exception when we have " render 'pages/' "