### PR TITLE
CACHING_DEPRECATION_WARNING added only when needed

### DIFF
--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -25,17 +25,17 @@ module HighVoltage
     end
 
     def action_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
       @action_caching = value
-    end
+    end.
 
     def action_caching_layout=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
       @action_caching_layout = value
     end
 
     def page_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
       @page_caching = value
     end
 

--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -25,17 +25,17 @@ module HighVoltage
     end
 
     def action_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
       @action_caching = value
     end
 
     def action_caching_layout=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
       @action_caching_layout = value
     end
 
     def page_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) if value
       @page_caching = value
     end
 

--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -27,7 +27,7 @@ module HighVoltage
     def action_caching=(value)
       ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
       @action_caching = value
-    end.
+    end
 
     def action_caching_layout=(value)
       ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false

--- a/lib/high_voltage/configuration.rb
+++ b/lib/high_voltage/configuration.rb
@@ -25,17 +25,23 @@ module HighVoltage
     end
 
     def action_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
+      unless value == false
+        ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      end
       @action_caching = value
     end
 
     def action_caching_layout=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
+      unless value == false
+        ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      end
       @action_caching_layout = value
     end
 
     def page_caching=(value)
-      ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING) unless value == false
+      unless value == false
+        ActiveSupport::Deprecation.warn(CACHING_DEPRECATION_WARNING)
+      end
       @page_caching = value
     end
 

--- a/spec/high_voltage/configuration_spec.rb
+++ b/spec/high_voltage/configuration_spec.rb
@@ -35,7 +35,7 @@ describe HighVoltage::Configuration do
     it { expect(HighVoltage.routes).to eq config_value }
   end
 
-  describe '#action_caching=' do
+  describe '#action_caching=true' do
     it 'displays a deprecation warning' do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 
@@ -48,7 +48,20 @@ describe HighVoltage::Configuration do
     end
   end
 
-  describe '#action_caching_layout=' do
+  describe '#action_caching=false' do
+    it 'does not display a deprecation warning' do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      HighVoltage.configure do |config|
+        config.action_caching = false
+      end
+
+      expect(ActiveSupport::Deprecation).not_to have_received(:warn)
+                                                .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
+    end
+  end
+
+  describe '#action_caching_layout=true' do
     it 'displays a deprecation warning' do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 
@@ -61,7 +74,20 @@ describe HighVoltage::Configuration do
     end
   end
 
-  describe '#page_caching=' do
+  describe '#action_caching_layout=false' do
+    it 'does not display a deprecation warning' do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      HighVoltage.configure do |config|
+        config.action_caching_layout = false
+      end
+
+      expect(ActiveSupport::Deprecation).not_to have_received(:warn)
+                                                .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
+    end
+  end
+
+  describe '#page_caching=true' do
     it 'displays a deprecation warning' do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 

--- a/spec/high_voltage/configuration_spec.rb
+++ b/spec/high_voltage/configuration_spec.rb
@@ -57,7 +57,7 @@ describe HighVoltage::Configuration do
       end
 
       expect(ActiveSupport::Deprecation).not_to have_received(:warn)
-                                                .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
+        .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
     end
   end
 
@@ -83,7 +83,7 @@ describe HighVoltage::Configuration do
       end
 
       expect(ActiveSupport::Deprecation).not_to have_received(:warn)
-                                                .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
+        .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
     end
   end
 
@@ -96,6 +96,19 @@ describe HighVoltage::Configuration do
       end
 
       expect(ActiveSupport::Deprecation).to have_received(:warn)
+        .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
+    end
+  end
+
+  describe '#page_caching=false' do
+    it 'displays a deprecation warning' do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      HighVoltage.configure do |config|
+        config.page_caching = false
+      end
+
+      expect(ActiveSupport::Deprecation).not_to have_received(:warn)
         .with(HighVoltage::Configuration::CACHING_DEPRECATION_WARNING)
     end
   end


### PR DESCRIPTION
We're seing annoying deprecation warnings  despite the fact that we do not use caching at all (it's disabled in an initialiser).