### PR TITLE
HighVoltage::PageFinder#clean_path should raise InvalidPageIdError when blank

### DIFF
--- a/lib/high_voltage/page_finder.rb
+++ b/lib/high_voltage/page_finder.rb
@@ -27,7 +27,11 @@ module HighVoltage
 
     def clean_path
       path = Pathname.new("/#{clean_id}")
-      path.cleanpath.to_s[1..-1]
+      path.cleanpath.to_s[1..-1].tap do |p|
+        if p.blank?
+          raise InvalidPageIdError.new "Invalid page id: #{@page_id}"
+        end
+      end
     end
 
     def clean_id

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -47,6 +47,10 @@ describe HighVoltage::PageFinder do
     end
   end
 
+  it "throws an exception if the path is empty" do
+    expect { find("關於我們/合作伙伴") }.to raise_error HighVoltage::InvalidPageIdError
+  end
+
   private
 
   def find(page_id)


### PR DESCRIPTION
When HighVoltage encounters a `page_id` with invalid characters, it strips those invalid characters and tries to calculate a file path from the result. If the resulting path is blank, HighVoltage will attempt to render a template at `pages/`. This causes an `ActionView::MissingTemplate` in production as a 500 error.

For example:

```ruby
pf = HighVoltage::PageFinder.new('關於我們/合作伙伴')
pf.find # => "pages/"
pf.send(:clean_id) # => "/"
pf.send(:clean_path) # => ""
```