### PR TITLE
Markdown files (*.md) are now in indexed

### DIFF
--- a/lib/high_voltage/page.rb
+++ b/lib/high_voltage/page.rb
@@ -38,7 +38,7 @@ module HighVoltage
     end
 
     def html_file_pattern
-      /\.(html)(\.[a-z]+)?$/
+      /((\.html(\.[a-z]+)?)|\.md)$/
     end
   end
 end


### PR DESCRIPTION
I'm using this project in combination with [markdown-rails](https://github.com/joliss/markdown-rails).

Some of my files weren't being indexed because their name was terminated with `.md` rather than `.html.erb` or `html.haml` or whatever...

With this update, markdown files are also indexed.