### PR TITLE
Update travis ruby test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ install:
 language:
   - ruby
 rvm:
-  - 2.0.0
-  - 2.1.5
-  - 2.2.0
+  - 2.0.0-p648
+  - 2.1.8
+  - 2.2.4
 script: 'bundle exec rake spec'
 notifications:
   email: false


### PR DESCRIPTION
Update to test against ruby 2.0.0-p648, 2.1.8, and 2.2.4