### PR TITLE
Remove check for .html in filename

### DIFF
--- a/lib/high_voltage/page.rb
+++ b/lib/high_voltage/page.rb
@@ -12,7 +12,7 @@ module HighVoltage
     end
 
     def valid?
-      exists? && file_in_content_path? && !directory? && !partial? && html?
+      exists? && file_in_content_path? && !directory? && !partial?
     end
 
     private
@@ -31,14 +31,6 @@ module HighVoltage
 
     def partial?
       File.basename(file_path).first == "_"
-    end
-
-    def html?
-      !file_path.match(html_file_pattern).nil?
-    end
-
-    def html_file_pattern
-      /\.(html)(\.[a-z]+)?$/
     end
   end
 end


### PR DESCRIPTION
HighVoltage.page_ids does not list shortcutted pages (e.g. foo.html.haml)