### PR TITLE
Remove check for .html in filename

### DIFF
--- a/lib/high_voltage/page.rb
+++ b/lib/high_voltage/page.rb
@@ -12,7 +12,7 @@ module HighVoltage
     end
 
     def valid?
-      exists? && file_in_content_path? && !directory? && !partial? && html?
+      exists? && file_in_content_path? && !directory? && !partial?
     end
 
     private


### PR DESCRIPTION
HighVoltage.page_ids does not list shortcutted pages (e.g. foo.html.haml)