### PR TITLE
Handle URL with explicit .html format on root routes

### DIFF
--- a/lib/high_voltage/constraints/root_route.rb
+++ b/lib/high_voltage/constraints/root_route.rb
@@ -2,20 +2,27 @@ module HighVoltage
   module Constraints
     # Routing constraint to validate request.path has a corresponding view
     class RootRoute
-      def self.matches?(request)
-        pattern = file_pattern(request.path)
+      class << self
+        def matches?(request)
+          page_id = clean_page_path(request.path)
+          pattern = file_pattern(page_id)
 
-        Dir.glob(pattern).any?
-      end
+          Dir.glob(pattern).any?
+        end
 
-      private
+        private
 
-      def self.file_pattern(page_id)
-        "#{content_path}#{page_id}.html*"
-      end
+        def clean_page_path(request_path)
+          request_path.sub(/\.html$/, "")
+        end
 
-      def self.content_path
-        Rails.root.join('app', 'views', HighVoltage.content_path).to_s
+        def file_pattern(page_id)
+          "#{content_path}#{page_id}.html*"
+        end
+
+        def content_path
+          Rails.root.join("app", "views", HighVoltage.content_path).to_s
+        end
       end
     end
   end

--- a/spec/constraints/root_route_spec.rb
+++ b/spec/constraints/root_route_spec.rb
@@ -1,18 +1,33 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe HighVoltage::Constraints::RootRoute, '.matches?' do
-  it 'returns true when the view file exists' do
+describe HighVoltage::Constraints::RootRoute, ".matches?" do
+  it "returns true when the view file exists" do
     request = double(path: 'index')
-    allow(Dir).to receive(:glob).and_return(["about.html.erb"])
+    file_path = Rails.root.join("app", "views", "pages", "index.html*").to_s
+
+    allow(Dir).to receive(:glob).with(file_path).and_return(["about.html.erb"])
 
     result = HighVoltage::Constraints::RootRoute.matches?(request)
 
     expect(result).to be true
   end
 
-  it 'returns false when the view files does not exist' do
+  it "returns true when the view file exists and url ends with .html" do
+    request = double(path: "index.html")
+    file_path = Rails.root.join("app", "views", "pages", "index.html*").to_s
+
+    allow(Dir).to receive(:glob).with(file_path).and_return(["about.html.erb"])
+
+    result = HighVoltage::Constraints::RootRoute.matches?(request)
+
+    expect(result).to be true
+  end
+
+  it "returns false when the view files does not exist" do
     request = double(path: 'index')
-    allow(File).to receive(:glob).and_return([])
+    file_path = Rails.root.join("app", "views", "pages", "index", ".html*").to_s
+
+    allow(File).to receive(:glob).with(file_path).and_return([])
 
     result = HighVoltage::Constraints::RootRoute.matches?(request)
 


### PR DESCRIPTION
### Root Routes Constraints

When using root route constraints, requesting an existing static page with an explicit format will raise a routing error.
For instance;  `/index` works as expected, but `/index.html` will return a 404.

This patch updates the root routes matcher to return correctly when the path ends with `.html`, and adds tests to ensure the right filename is being checked for .