### PR TITLE
Make current_page available in rendered view

### DIFF
--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -18,7 +18,7 @@ module HighVoltage::StaticPage
   def show
     render(
       template: current_page,
-      locals: { current_page: current_page }
+      locals: { current_page: current_page },
     )
   end
 

--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -16,7 +16,10 @@ module HighVoltage::StaticPage
   end
 
   def show
-    render template: current_page
+    render(
+      template: current_page,
+      locals: { current_page: current_page }
+    )
   end
 
   def invalid_page


### PR DESCRIPTION
this issue: https://github.com/thoughtbot/high_voltage/issues/235

Unfortunately I can't find how to test locals on render methods.