### PR TITLE
Utilize Rails view lookup paths to find templates

### DIFF
--- a/lib/high_voltage/constraints/root_route.rb
+++ b/lib/high_voltage/constraints/root_route.rb
@@ -2,27 +2,28 @@ module HighVoltage
   module Constraints
     # Routing constraint to validate request.path has a corresponding view
     class RootRoute
-      class << self
-        def matches?(request)
-          page_id = clean_page_path(request.path)
-          pattern = file_pattern(page_id)
+      def initialize
+        @lookup_context = ActionView::LookupContext.new(
+          Rails.configuration.paths["app/views"],
+        )
+      end
 
-          Dir.glob(pattern).any?
-        end
+      def matches?(request)
+        page_id = clean_page_path(request.path)
+        template = File.join(content_path, page_id)
+        lookup_context.exists? template
+      end
 
-        private
+      private
 
-        def clean_page_path(request_path)
-          request_path.sub(/\.html$/, "")
-        end
+      attr_reader :lookup_context
 
-        def file_pattern(page_id)
-          "#{content_path}#{page_id}.html*"
-        end
+      def clean_page_path(request_path)
+        request_path.sub(/\.html$/, "")
+      end
 
-        def content_path
-          Rails.root.join("app", "views", HighVoltage.content_path).to_s
-        end
+      def content_path
+        HighVoltage.content_path
       end
     end
   end

--- a/lib/high_voltage/route_drawers/root.rb
+++ b/lib/high_voltage/route_drawers/root.rb
@@ -8,7 +8,7 @@ module HighVoltage
           "/*id" => 'high_voltage/pages#show',
           :as => :page,
           :format => false,
-          :constraints => HighVoltage::Constraints::RootRoute
+          :constraints => HighVoltage::Constraints::RootRoute.new,
         }
       end
     end

--- a/spec/constraints/root_route_spec.rb
+++ b/spec/constraints/root_route_spec.rb
@@ -1,36 +1,29 @@
 require "spec_helper"
 
-describe HighVoltage::Constraints::RootRoute, ".matches?" do
-  it "returns true when the view file exists" do
-    request = double(path: 'index')
-    file_path = Rails.root.join("app", "views", "pages", "index.html*").to_s
+describe HighVoltage::Constraints::RootRoute do
+  describe "#matches?" do
+    it "returns true when the view file exists" do
+      request = double(path: "exists")
 
-    allow(Dir).to receive(:glob).with(file_path).and_return(["about.html.erb"])
+      result = described_class.new.matches?(request)
 
-    result = HighVoltage::Constraints::RootRoute.matches?(request)
+      expect(result).to be true
+    end
 
-    expect(result).to be true
-  end
+    it "returns true when the view file exists and url ends with .html" do
+      request = double(path: "exists.html")
 
-  it "returns true when the view file exists and url ends with .html" do
-    request = double(path: "index.html")
-    file_path = Rails.root.join("app", "views", "pages", "index.html*").to_s
+      result = described_class.new.matches?(request)
 
-    allow(Dir).to receive(:glob).with(file_path).and_return(["about.html.erb"])
+      expect(result).to be true
+    end
 
-    result = HighVoltage::Constraints::RootRoute.matches?(request)
+    it "returns false when the view files does not exist" do
+      request = double(path: "index")
 
-    expect(result).to be true
-  end
+      result = described_class.new.matches?(request)
 
-  it "returns false when the view files does not exist" do
-    request = double(path: 'index')
-    file_path = Rails.root.join("app", "views", "pages", "index", ".html*").to_s
-
-    allow(File).to receive(:glob).with(file_path).and_return([])
-
-    result = HighVoltage::Constraints::RootRoute.matches?(request)
-
-    expect(result).to be false
+      expect(result).to be false
+    end
   end
 end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -10,6 +10,7 @@ module Dummy
     config.action_controller.perform_caching = true
     config.action_controller.cache_store = :memory_store
     config.root = "spec/fixtures"
+    config.paths["app/views"] << "spec/fixtures/app/views"
   end
 end
 Dummy::Application.initialize!


### PR DESCRIPTION
In the root_route constraint, make use of the Rails view context lookup
in order to determine if a given template exists or not. This leaves us
with not having to deal with manually looking files up in the view
structure since Rails is good at this already.

Doing this allows us to resolve #241 and #247