### PR TITLE
CVE-2017-9050: Upgrade Nokogiri 1.8.0 -> 1.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,10 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.2)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -110,4 +110,4 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
 
 BUNDLED WITH
-   1.14.6
+   1.16.0.pre.3


### PR DESCRIPTION
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050