### PR TITLE
Valid pages should include anything Rails handles

### DIFF
--- a/lib/high_voltage/page.rb
+++ b/lib/high_voltage/page.rb
@@ -8,17 +8,21 @@ module HighVoltage
     end
 
     def id
-      file_path.gsub(content_path, "").gsub(html_file_pattern, "")
+      file_path.gsub(content_path, "").split(".").first
     end
 
     def valid?
-      exists? && file_in_content_path? && !directory? && !partial? && html?
+      exists? && file_in_content_path? && !directory? && !partial? && handled?
     end
 
     private
 
+    def handler_extension
+      File.extname(file_path).delete(".")
+    end
+
     def exists?
-      File.exists?(file_path)
+      File.exist?(file_path)
     end
 
     def file_in_content_path?
@@ -33,12 +37,12 @@ module HighVoltage
       File.basename(file_path).first == "_"
     end
 
-    def html?
-      !file_path.match(html_file_pattern).nil?
+    def handled?
+      available_handlers.include? handler_extension
     end
 
-    def html_file_pattern
-      /\.(html)(\.[a-z]+)?$/
+    def available_handlers
+      ActionView::Template.template_handler_extensions
     end
   end
 end

--- a/spec/fixtures/app/views/pages/exists_without_html_extension.erb
+++ b/spec/fixtures/app/views/pages/exists_without_html_extension.erb
@@ -1,0 +1,1 @@
+<h1>Exists without html extension</h1>

--- a/spec/high_voltage/page_collector_spec.rb
+++ b/spec/high_voltage/page_collector_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe HighVoltage::PageCollector do
   it "produces an array of all page_ids under pages/" do
-    expect(HighVoltage.page_ids).to eq [
+    expect(HighVoltage.page_ids).to match_array [
       "about",
       "also_dir/also_nested",
       "also_exists",
@@ -12,6 +12,8 @@ describe HighVoltage::PageCollector do
       "exists",
       "exists_but_references_nonexistent_partial",
       "rot13",
+      "exists_without_html_extension",
+      "text",
     ]
   end
 

--- a/spec/high_voltage/page_spec.rb
+++ b/spec/high_voltage/page_spec.rb
@@ -43,10 +43,10 @@ describe HighVoltage::Page do
     expect(page).to_not be_valid
   end
 
-  it "is invalid for a text page" do
-    page = page(full_file_path("text.txt.erb"))
+  it "is valid for files without a format present" do
+    page = page(full_file_path("exists_without_html_extension.erb"))
 
-    expect(page).to_not be_valid
+    expect(page).to be_valid
   end
 
   private


### PR DESCRIPTION
Instead of requiring an extension like `.html.haml`, allow `.haml`. Look
up what handlers exist within the application using
`ActionView::template.template_handler_extensions`.

Resolves https://github.com/thoughtbot/high_voltage/issues/211