### PR TITLE
Fix UTF-8 encoding error.

### DIFF
--- a/lib/high_voltage/page_finder.rb
+++ b/lib/high_voltage/page_finder.rb
@@ -14,6 +14,8 @@ module HighVoltage
         raise InvalidPageIdError.new "Invalid page id: #{page_id}"
       end
       path
+    rescue ArgumentError
+      raise InvalidPageIdError.new "Invalid page id: #{page_id}"
     end
 
     def content_path

--- a/spec/high_voltage/page_finder_spec.rb
+++ b/spec/high_voltage/page_finder_spec.rb
@@ -70,6 +70,11 @@ describe HighVoltage::PageFinder do
       expect { find("dummy/../../secret") }.
         to raise_error HighVoltage::InvalidPageIdError
     end
+
+    it "throws an exception if invalid byte sequence in page_id" do
+      expect { find("\xD0½\xA8\xCEļ\xFE\xBC\xD0.zip") }.
+        to raise_error HighVoltage::InvalidPageIdError
+    end
   end
 
   private


### PR DESCRIPTION
Hi there & thanks for the great gem!

We get the occasional random request which is caused by an invalid UTF-8 char in the URL. This then gets passed through to `high_voltage` which throws an exception because the [call to tr](https://github.com/patrickdavey/high_voltage/blob/1b5012986ac7e243717b77ee7e06425f069534dd/lib/high_voltage/page_finder.rb#L12) throws an exception `"An ArgumentError occurred in pages#show:" invalid byte sequence in UTF-8`.

This PR simply catches the ArgumentError and raises your `InvalidPageIdError`, which ultimately will mean a 404 error rather than an exception.