### PR TITLE
Do not ship develop preparation script.

### DIFF
--- a/high_voltage.gemspec
+++ b/high_voltage.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_development_dependency('activesupport', '>= 3.1.0')


### PR DESCRIPTION
The latest version contains the development file that is `setup` script. so, high_voltage put the `setup` script to the global path on the box.

It should not be contained in the published gem. 