### PR TITLE
Update grid layout

### DIFF
--- a/_includes/dangerdanger-white.svg
+++ b/_includes/dangerdanger-white.svg
@@ -1,5 +1,5 @@
 <svg version="1.1"
-   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/" viewBox="0 0 89 120.5" class="references-dangerdanger" >
+   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/" viewBox="0 0 89 120.5" class="dangerdanger" >
   <g>
     <polygon fill="none" stroke="#fff" stroke-width="3.5" stroke-linejoin="bevel" stroke-miterlimit="10"
       points="1.7,52.4 31.4,1 61,52.4"/>

--- a/_includes/dangerdanger.svg
+++ b/_includes/dangerdanger.svg
@@ -1,5 +1,5 @@
 <svg version="1.1"
-   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/" viewBox="0 0 89 120.5" class="references-dangerdanger" >
+   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/" viewBox="0 0 89 120.5" class="dangerdanger" >
 <defs>
 </defs>
 <g>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,15 @@
 <footer class="site-footer">
-
   <p class="cite">
     <a href="{{ site.thoughtbot_url }}">{% include ralph.svg %}</a>
-    High Voltage is maintained and funded by <a href="{{ site.thoughtbot_url }}">thoughtbot</a>
+    
+    <span>High Voltage is maintained and funded by <a href="{{ site.thoughtbot_url }}">thoughtbot</a></span>
   </p>
+
   <p class="copyright">
     <span>Copyright © 2013–2014 thoughtbot, inc.</span>
+
     <span>high_voltage is free software.</span>
+    
     <span>high_voltage may be redistributed under the terms specified in the <a href="{{ site.license_url }}">license</a>.</span>
   </p>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,19 +2,21 @@
   <a href="{{ site.repository_url }}" class="site-navigation-item">
     github
   </a>
+  
   <a href="{{ site.documentation_url }}" class="site-navigation-item">
     docs
   </a>
+
   <a href="{{ site.thoughtbot_url }}" class="site-navigation-item">
     thoughtbot
   </a>
 </nav>
 
 <header class="site-header">
-
   <h1 class="site-title">
     {% include high_voltage-logo.svg %}
   </h1>
+
   <p class="site-description">High Voltage serves static pages in your Rails app</p>
 
   <a class="site-header-dangerdanger" href="https://www.youtube.com/watch?v=HD5tnb2RBYg">{% include dangerdanger-white.svg %}</a>

--- a/index.html
+++ b/index.html
@@ -3,26 +3,25 @@ layout: default
 ---
 
 <main>
-
   <section class="install">
     <header class="install-header">
       <h1>01. Install</h1>
     </header>
+
     <section class="install-direction">
-      <div class="install-direction-step">
-        <p class="install-direction-instructions">Install high_voltage in your local system</p>
-        <code class="install-direction-sample">$ gem install high_voltage</code>
-      </div>
-      <div class="install-direction-step">
-        <p class="install-direction-instructions">Include high_voltage in your gemfile</p>
-        <code class="install-direction-sample">gem "<em>high_voltage</em>"</code>
-      </div>
+      <p class="install-direction-instructions">Install high_voltage in your local system</p>
+
+      <code class="install-direction-sample">$ gem install high_voltage</code>
+
+      <p class="install-direction-instructions">Include high_voltage in your gemfile</p>
+
+      <code class="install-direction-sample">gem "<em>high_voltage</em>"</code>
     </section>
-    <section class="install-direction install_direction-optional">
-      <div class="install-direction-step">
-        <p class="install-direction-instructions">For Rails versions prior to 3.0, use the 0.9.2 tag of high_voltage</p>
-        <code class="install-direction-sample">$ gem "<em>high_voltage</em>", "~> 0.9.2"</code>
-      </div>
+
+    <section class="install-direction">
+      <p class="install-direction-instructions">For Rails versions prior to 3.0, use the 0.9.2 tag of high_voltage</p>
+
+      <code class="install-direction-sample">$ gem "<em>high_voltage</em>", "~> 0.9.2"</code>
     </section>
   </section>
 
@@ -30,8 +29,10 @@ layout: default
     <header class="usage-header">
       <h1>02. USAGE</h1>
     </header>
+
     <div class="usage-content">
       <p class="usage-directions">Write your static pages and put them in the <code>/app/views/pages</code> directory</p>
+
       {% include usage_illustration-small.svg %}
       {% include usage_illustration-large.svg %}
     </div>
@@ -41,8 +42,7 @@ layout: default
     <p class="references-documentation">
       For advanced configuration options <span>—</span> consult project <a href="{{ site.documentation_url }}">documentation</a>
     </p>
-    <a href="https://www.youtube.com/watch?v=HD5tnb2RBYg">{% include dangerdanger.svg %}</a>
 
+    <a class="references-dangerdanger" href="https://www.youtube.com/watch?v=HD5tnb2RBYg">{% include dangerdanger.svg %}</a>
   </footer>
-
 </main>

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -31,6 +31,9 @@ html, *, *:before, *:after {
 @import "lists";
 @import "buttons";
 
+// Components
+@import "components/dangerdanger";
+
 // Page Modules
 @import "modules/footer";
 @import "modules/header";

--- a/stylesheets/components/_dangerdanger.scss
+++ b/stylesheets/components/_dangerdanger.scss
@@ -1,0 +1,6 @@
+.dangerdanger {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 5.5em;
+}

--- a/stylesheets/modules/_footer.scss
+++ b/stylesheets/modules/_footer.scss
@@ -9,9 +9,14 @@
 
   .cite {
     @include clearfix();
+    display: grid;
+    grid-template-columns: 1fr;
     font-size: 1.25em;
     margin-bottom: $gutter-width;
-    max-width: 22em;
+
+    @media screen and (min-width : $medium-screen) {
+      grid-template-columns: min-content minmax(auto, 18em);
+    }
   }
 
   .ralph {
@@ -20,7 +25,6 @@
     width: 5rem;
     @media screen and (min-width : $medium-screen) {
 
-      float: left;
       margin-right: $gutter-width;
       width: 3.75rem;
     }

--- a/stylesheets/modules/_header.scss
+++ b/stylesheets/modules/_header.scss
@@ -1,7 +1,16 @@
 .site-header {
   @extend %container;
   background-color: $base-accent-color;
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-content: space-between;
   margin-bottom: $gutter-width;
+
+  @media screen and (min-width : $large-screen) {
+    grid-template-areas: "logo logo"
+                         "desc icon";
+    grid-template-columns: minmax(auto, 30em);
+  }
 }
 
 .site-title {
@@ -10,15 +19,17 @@
   svg {
     max-width: 100%;
   }
+
+  @media screen and (min-width : $large-screen) {
+    grid-area: logo;
+  }
 }
 
 .site-description {
   border: 1px solid $base-background-color;
   color: $base-background-color;
-  float: left;
   font-size: 1.25em;
   margin: 0;
-  max-width: 22em;
   padding: ($gutter-width * 0.8) $gutter-width;
 
   @media screen and (min-width : $large-screen) {
@@ -31,5 +42,6 @@
 
   @media screen and (min-width : $large-screen) {
     display: inline;
+    justify-self: end;
   }
 }

--- a/stylesheets/modules/_install.scss
+++ b/stylesheets/modules/_install.scss
@@ -14,33 +14,35 @@
 }
 
 .install-direction {
+  display: grid;
+  grid-template-columns: 1fr;
   padding: 0;
   text-transform: lowercase;
+
+  @media screen and (min-width : $large-screen) {
+    grid-template-columns: 1fr auto;
+  }
 }
 
 .install-direction-instructions,
 .install-direction-sample {
-  padding: $gutter-width;
   margin: 0;
-}
-
-.install-direction-step {
-  @include clearfix;
-}
-
-.install-direction-instructions {
-  float: left;
+  padding: $gutter-width;
 }
 
 .install-direction-sample {
   border-bottom: $base-border;
-  border-left: $base-border;
-  float: right;
   font-size: 1.25em;
   min-width: 25rem;
+  padding-top: 0;
 
-  .install-direction-step:last-child & {
+  &:last-child {
     border-bottom-style: none;
+  }
+
+  @media screen and (min-width : $large-screen) {
+    border-left: $base-border;
+    padding-top: $gutter-width;
   }
 }
 

--- a/stylesheets/modules/_references.scss
+++ b/stylesheets/modules/_references.scss
@@ -1,17 +1,22 @@
 .references {
   @include clearfix;
+  display: grid;
+  grid-template-columns: 1fr;
   margin: 0 auto $gutter-width auto;
   max-width: $section-max-width;
   text-transform: lowercase;
+
+  @media screen and (min-width : $medium-screen) {
+    grid-template-columns: auto 1fr;
+  }
 }
 
 .references-documentation {
   border: 1px solid $base-accent-color;
   padding: $gutter-width;
-  float: left;
   font-size: 1.25em;
 
-  @media screen and (min-width : $large-screen) {
+  @media screen and (min-width : $medium-screen) {
 
     span:after {
       content: "";
@@ -21,12 +26,7 @@
 }
 
 .references-dangerdanger {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 5.5em;
-
-  @media screen and (min-width : $large-screen) {
-    float: right;
+  @media screen and (min-width : $medium-screen) {
+    justify-self: end;
   }
 }


### PR DESCRIPTION
This commit replaces `float` properties with `grid` layout to support
better responsive design and reduce redundant `div` wrappers.

Future work:
* reduce the use of `clearfix` if possible

Before:
![image](https://user-images.githubusercontent.com/49497651/73307403-25c55c80-41ec-11ea-929d-ab688ec2d20a.png)

After:
![image](https://user-images.githubusercontent.com/49497651/73307429-2fe75b00-41ec-11ea-9cd5-a7e8e973403a.png)
