### PR TITLE
Remove unnecessary `clearfix`

### DIFF
--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -20,7 +20,6 @@ html, *, *:before, *:after {
 
 // Extends
 @import "extends/button";
-@import "extends/clearfix";
 @import "extends/container";
 @import "extends/hide-text";
 

--- a/stylesheets/extends/_clearfix.scss
+++ b/stylesheets/extends/_clearfix.scss
@@ -1,3 +1,0 @@
-%clearfix {
-  @include clearfix;
-}

--- a/stylesheets/extends/_container.scss
+++ b/stylesheets/extends/_container.scss
@@ -1,5 +1,4 @@
 %container {
-  @include clearfix;
   margin-left: auto;
   margin-right: auto;
   max-width: $section-max-width;

--- a/stylesheets/modules/_footer.scss
+++ b/stylesheets/modules/_footer.scss
@@ -8,7 +8,6 @@
   }
 
   .cite {
-    @include clearfix();
     display: grid;
     grid-template-columns: 1fr;
     font-size: 1.25em;

--- a/stylesheets/modules/_references.scss
+++ b/stylesheets/modules/_references.scss
@@ -1,5 +1,4 @@
 .references {
-  @include clearfix;
   display: grid;
   grid-template-columns: 1fr;
   margin: 0 auto $gutter-width auto;


### PR DESCRIPTION
This commit removes `clearfix` properties since all `float` layouts have
been removed prior to this change.

* also, removes related `@extend` placeholders.
* This update doesn't contain any visual changes.