### PR TITLE
Generalize style of `code` element

### DIFF
--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -95,6 +95,10 @@ cite {
   }
 }
 
+code {
+  @extend %code;
+}
+
 code em {
   font-style: normal;
   color: $alt-accent-color;

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -20,6 +20,7 @@ html, *, *:before, *:after {
 
 // Extends
 @import "extends/button";
+@import "extends/code";
 @import "extends/container";
 @import "extends/hide-text";
 

--- a/stylesheets/extends/_code.scss
+++ b/stylesheets/extends/_code.scss
@@ -1,0 +1,3 @@
+%code {
+  font-family: $monospace-font-family;
+}

--- a/stylesheets/modules/_install.scss
+++ b/stylesheets/modules/_install.scss
@@ -20,7 +20,7 @@
   text-transform: lowercase;
 
   @media screen and (min-width : $large-screen) {
-    grid-template-columns: 1fr minmax(0, 25rem);
+    grid-template-columns: 1fr minmax(0, 26rem);
   }
 }
 

--- a/stylesheets/modules/_usage.scss
+++ b/stylesheets/modules/_usage.scss
@@ -14,7 +14,7 @@
   position: relative;
 
   svg {
-    font-family: 'Anonymous Pro';
+    @extend %code;
     max-width: 100%;
   }
 }


### PR DESCRIPTION
This commit updates the font style of `code` element to improve the consistency
of visual cue for the recurring use.

Before:
![image](https://user-images.githubusercontent.com/49497651/73487527-30f7c400-4375-11ea-85b7-e55d8de3a91b.png)

After:
![image](https://user-images.githubusercontent.com/49497651/73487563-42d96700-4375-11ea-9a03-2aeb76077fa2.png)
