### PR TITLE
Expose simple override to support ActionController Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Most common reasons to override?
   * You need to render different layouts for different pages.
   * You need to render a partial from the `app/views/pages` directory.
   * You need to use your own Page resource and would like to use StaticPage resource for high voltage
+  * You want to enable [response streaming](https://api.rubyonrails.org/classes/ActionController/Streaming.html)
 
 Create a `PagesController` of your own:
 
@@ -281,6 +282,25 @@ end
 Use this to create a custom file mapping, clean filenames for your file
 system, A/B test, and so on.
 
+## ActionController Streaming
+
+Enable
+[ActionController::Streaming](https://api.rubyonrails.org/classes/ActionController/Streaming.html)
+by overriding `stream_response?`
+
+```ruby
+# app/controllers/pages_controller.rb
+class PagesController < ApplicationController
+  include HighVoltage::StaticPage
+
+  private
+
+  def stream_response?
+    true
+  end
+end
+```
+
 ## Localization
 
 [Rails I18n guides](http://guides.rubyonrails.org/i18n.html).
@@ -369,7 +389,7 @@ Thank you, [contributors]!
 
 ## License
 
-High Voltage is copyright © 2009-2018 thoughtbot. It is free software, and may
+High Voltage is copyright © 2009-2022 thoughtbot. It is free software, and may
 be redistributed under the terms specified in the [`LICENSE`] file.
 
 [`LICENSE`]: /MIT-LICENSE

--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -19,7 +19,7 @@ module HighVoltage::StaticPage
     render(
       template: current_page,
       locals: { current_page: current_page },
-      stream: stream_response?
+      stream: stream_response?,
     )
   end
 

--- a/app/controllers/concerns/high_voltage/static_page.rb
+++ b/app/controllers/concerns/high_voltage/static_page.rb
@@ -19,6 +19,7 @@ module HighVoltage::StaticPage
     render(
       template: current_page,
       locals: { current_page: current_page },
+      stream: stream_response?
     )
   end
 
@@ -38,5 +39,9 @@ module HighVoltage::StaticPage
 
   def page_finder_factory
     HighVoltage::PageFinder
+  end
+
+  def stream_response?
+    false
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -17,6 +17,10 @@ describe HighVoltage::PagesController do
       it "uses the default layout used by ApplicationController" do
         expect(response).to render_template("layouts/application")
       end
+
+      it "uses the default render streaming false" do
+        expect(response.headers['Transfer-Encoding']).to be_nil
+      end
     end
 
     describe "on GET to /pages/dir/nested" do
@@ -47,6 +51,16 @@ describe HighVoltage::PagesController do
       get :show, params: {
         id: "exists_but_references_nonexistent_partial",
       }
+    end
+  end
+
+  context "using streaming response" do
+    describe "on GET to /pages/exists" do
+      before { get :show, params: { id: "exists" } }
+
+      it "uses the custom configured layout" do
+        expect(response.headers['Transfer-Encoding']).to_not be_nil
+      end
     end
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -19,7 +19,7 @@ describe HighVoltage::PagesController do
       end
 
       it "uses the default render streaming false" do
-        expect(response.headers['Transfer-Encoding']).to be_nil
+        expect(response.headers["Transfer-Encoding"]).to be_nil
       end
     end
 
@@ -58,8 +58,9 @@ describe HighVoltage::PagesController do
     describe "on GET to /pages/exists" do
       before { get :show, params: { id: "exists" } }
 
-      it "uses the custom configured layout" do
-        expect(response.headers['Transfer-Encoding']).to_not be_nil
+      it "responds with chunked transfer encoding" do
+        expect(response.headers["Transfer-Encoding"]).to_not be_nil
+        expect(response.headers["Transfer-Encoding"]).to eq "chunked"
       end
     end
   end


### PR DESCRIPTION
Add support to allow static pages to stream from a top down approach with [ActionController::Streaming](https://api.rubyonrails.org/classes/ActionController/Streaming.html), and [provide](https://apidock.com/rails/ActionView/Helpers/CaptureHelper/provide)

Trying to KISS, it's just a simple options key to `render`, so I figured if you wanted to change from defaults, just override in  `PagesController` similar to layouts.