### PR TITLE
Fix broken thoughtbot logo + copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,14 +369,14 @@ Thank you, [contributors]!
 
 ## License
 
-High Voltage is copyright © 2009-2023 thoughtbot. It is free software, and may
+High Voltage is copyright © 2009-2024 thoughtbot. It is free software, and may
 be redistributed under the terms specified in the [`LICENSE`] file.
 
 [`LICENSE`]: /MIT-LICENSE
 
 ## About thoughtbot
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
 
 High Voltage is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
Replace thoughtbot's logo with another link used on other thoughtbot repositories. Found this link from https://github.com/thoughtbot/templates/pull/21 (thanks @sarahraqueld 🎉 )