### PR TITLE
Adjust routes drawing to be compatible with Rails main

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ HighVoltage.parent_engine.routes.draw do
   end
 
   if HighVoltage.routes
-    get HighVoltage.route_drawer.match_attributes
+    get **HighVoltage.route_drawer.match_attributes
   end
 end


### PR DESCRIPTION
Some days ago, Rails [changed](https://github.com/rails/rails/commit/3b4255e1800d0b53c96db5aeb88aaa66163f74d5) how the routing mapper accept parameters so that it expects keywords instead of hashes. 

This PR adjusts High Voltage so that it stops printing deprecation warnings.

All tests should continue to pass